### PR TITLE
[FIX] base: import xml bank statement without admin rights

### DIFF
--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -21,10 +21,6 @@ S8vVzNDLy9EVEQgU1ZHIDIwMDAxMTAyLy9FTiIKICJodHRwOi8vd3d3LnczLm9yZy9UUi8yMDAwL0NSL
 VEQvc3ZnLTIwMDAxMTAyLmR0ZCI+Cgo8c3ZnIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiPgogIDxnIHRyYW5zZm9ybT0idHJ
 hbnNsYXRlKDUwLDUwKSI+CiAgICA8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMTUwIiBoZWlnaHQ9IjUwIiBzdHlsZT0iZmlsbD
 pyZWQ7IiAvPgogIDwvZz4KCjwvc3ZnPgo="""
-# minimal zip file with an empty `t.txt` file
-ZIP = b"""UEsDBBQACAAIAGFva1AAAAAAAAAAAAAAAAAFACAAdC50eHRVVA0AB5bgaF6W4GheluBoXnV4CwABBOgDAAAE6AMAAA
-MAUEsHCAAAAAACAAAAAAAAAFBLAQIUAxQACAAIAGFva1AAAAAAAgAAAAAAAAAFACAAAAAAAAAAAACkgQAAAAB0LnR4dFVUDQAHlu
-BoXpbgaF6W4GhedXgLAAEE6AMAAAToAwAAUEsFBgAAAAABAAEAUwAAAFUAAAAAAA=="""
 
 
 class test_guess_mimetype(BaseCase):
@@ -72,11 +68,6 @@ class test_guess_mimetype(BaseCase):
         # Tests that whitespace padded SVG are not detected as SVG
         mimetype = guess_mimetype(b"   " + content, default='test')
         self.assertNotIn("svg", mimetype)
-
-    def test_mimetype_zip(self):
-        content = base64.b64decode(ZIP)
-        mimetype = guess_mimetype(content, default='test')
-        self.assertEqual(mimetype, 'application/zip')
 
 
 

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -1,8 +1,6 @@
 #
 # test cases for new-style fields
 #
-import base64
-
 from datetime import date, datetime, time
 
 from odoo import fields
@@ -1092,27 +1090,6 @@ class TestFields(common.TransactionCase):
         discussion.copy({'messages': [(6, 0, message1.ids)]})
         self.assertEqual(count(message), 1)
         self.assertEqual(count(message1), 0)
-
-    def test_85_binary_guess_zip(self):
-        from odoo.addons.base.tests.test_mimetypes import ZIP
-        # Regular ZIP files can be uploaded by non-admin users
-        self.env['test_new_api.binary_svg'].sudo(
-            self.env.ref('base.user_demo'),
-        ).create({
-            'name': 'Test without attachment',
-            'image_wo_attachment': base64.b64decode(ZIP),
-        })
-
-    def test_86_text_base64_guess_svg(self):
-        from odoo.addons.base.tests.test_mimetypes import SVG
-        with self.assertRaises(UserError) as e:
-            self.env['test_new_api.binary_svg'].sudo(
-                self.env.ref('base.user_demo'),
-            ).create({
-                'name': 'Test without attachment',
-                'image_wo_attachment': SVG.decode("utf-8"),
-            })
-        self.assertEqual(e.exception.name, 'Only admins can upload SVG files.')
 
     def test_90_binary_svg(self):
         from odoo.addons.base.tests.test_mimetypes import SVG

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -11,7 +11,6 @@ from operator import attrgetter
 import itertools
 import logging
 import base64
-import binascii
 
 import pytz
 
@@ -1812,17 +1811,8 @@ class Binary(Field):
             return None
         # Detect if the binary content is an SVG for restricting its upload
         # only to system users.
-        magic_bytes = {
-            b'P',  # first 6 bits of '<' (0x3C) b64 encoded
-            b'<',  # plaintext XML tag opening
-        }
-        if isinstance(value, str):
-            value = value.encode()
-        if value[:1] in magic_bytes:
-            try:
-                decoded_value = base64.b64decode(value.translate(None, b'\r\n'), validate=True)
-            except binascii.Error:
-                decoded_value = value
+        if value[:1] == b'P':  # Fast detection of first 6 bits of '<' (0x3C)
+            decoded_value = base64.b64decode(value)
             # Full mimetype detection
             if (guess_mimetype(decoded_value).startswith('image/svg') and
                     not record.env.user._is_system()):


### PR DESCRIPTION
Before this commit, when a user without admin rights tries to import a
xml bank statement an error is raised. This occurs because all xml files
are considered as svg files, and for security reasons, only the admin
can upload svg files. Before, abb8328,
only binary base64 files were check if they were xml files. Since this
commit, all files are tested (binary or string files; base64 or plain
text files).

This commit will revert abb8328fc40ae89cfac6e8fff91bcda151da5c02

This is a temporary revert, waiting #28936 to be approved.

opw-2224635
opw-2221116
opw-2225971
opw-2223796

closes odoo/odoo#48522

Signed-off-by: Jorge Pinna Puissant (jpp) <jpp@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
